### PR TITLE
Fix hash parsing

### DIFF
--- a/public/javascripts/hack.js
+++ b/public/javascripts/hack.js
@@ -255,7 +255,7 @@ var settings = {
        title            : "Gui Hacker",
        gui              : true
     },
-    hash = document.location.hash.substring(1),
+    hash = decodeURIComponent(document.location.hash.substring(1)),
     userSettings = {};
 
 if (hash){


### PR DESCRIPTION
On my browser, the app doesn't work if you pass a hash parameter, because `hash` is URL-encoded. This change fixes the problem.